### PR TITLE
pytest-mock 3.10.0 [rebuild for osx-64 py312 and py313]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ test:
   requires:
     - pytest-asyncio
     - pip
+    # py for py.code in test_monkeypatch_ini
+    - py
   source_files:
     - tests
   imports:
@@ -45,7 +47,7 @@ test:
     # check that pip gets the correct version 
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest --help
-    - pytest -vv tests -k "not test_monkeypatch_ini"
+    - pytest -vv tests
 
 about:
   home: https://github.com/pytest-dev/pytest-mock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,18 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ hash }}
+  patches:
+    - patches/0001-update-expected-message-to-match.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   skip: True  # [py<37]
 
 requirements:
+  build:
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip
@@ -31,13 +36,14 @@ test:
   requires:
     - pytest-asyncio
     - pip
-
   source_files:
     - tests
   imports:
     - pytest_mock
   commands:
     - pip check
+    # check that pip gets the correct version 
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest --help
     - pytest -vv tests -k "not test_monkeypatch_ini"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,8 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Thin-wrapper around the mock package for easier use with py.test
+  description: |
+    Thin-wrapper around the mock package for easier use with py.test
   dev_url: https://github.com/pytest-dev/pytest-mock
   doc_url: https://pytest-mock.readthedocs.io
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,19 @@
 {% set name = "pytest-mock" %}
 {% set version = "3.10.0" %}
-{% set hash = "fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ hash }}
+  sha256: fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f
   patches:
     - patches/0001-update-expected-message-to-match.patch
 
 build:
   number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<37]
 
 requirements:

--- a/recipe/patches/0001-update-expected-message-to-match.patch
+++ b/recipe/patches/0001-update-expected-message-to-match.patch
@@ -1,0 +1,34 @@
+From 39547ecdc051123750dd17a890c0492ac5d5b1a0 Mon Sep 17 00:00:00 2001
+From: Daniel Garcia Moreno <daniel.garcia@suse.com>
+Date: Wed, 20 Dec 2023 13:39:14 +0100
+Subject: [PATCH] Update expected message to match python 3.11.7
+
+https://github.com/python/cpython/issues/111019
+---
+ tests/test_pytest_mock.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/tests/test_pytest_mock.py b/tests/test_pytest_mock.py
+index c185f2a..01534a4 100644
+--- a/tests/test_pytest_mock.py
++++ b/tests/test_pytest_mock.py
+@@ -25,6 +25,8 @@
+ 
+ # Python 3.8 changed the output formatting (bpo-35500), which has been ported to mock 3.0
+ NEW_FORMATTING = sys.version_info >= (3, 8)
++# Python 3.11.7 changed the output formatting, https://github.com/python/cpython/issues/111019
++NEWEST_FORMATTING = sys.version_info >= (3, 11, 7)
+ 
+ if sys.version_info[:2] >= (3, 8):
+     from unittest.mock import AsyncMock
+@@ -240,7 +242,9 @@ def test_repr_with_name(self, mocker: MockerFixture) -> None:
+ 
+     def __test_failure_message(self, mocker: MockerFixture, **kwargs: Any) -> None:
+         expected_name = kwargs.get("name") or "mock"
+-        if NEW_FORMATTING:
++        if NEWEST_FORMATTING:
++            msg = "expected call not found.\nExpected: {0}()\n  Actual: not called."
++        elif NEW_FORMATTING:
+             msg = "expected call not found.\nExpected: {0}()\nActual: not called."
+         else:
+             msg = "Expected call: {0}()\nNot called"


### PR DESCRIPTION
pytest-mock 3.10.0

**Destination channel:** defaults

### Links

- [PKG-6299]

### Explanation of changes:

- [rebuild for osx-64 py312 and py313](https://github.com/AnacondaRecipes/pytest-mock-feedstock/commit/7317e0567528a0732940db987debf9f369d276e9)
- `osx-64` was missing `py312` artifacts


[PKG-6299]: https://anaconda.atlassian.net/browse/PKG-6299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ