### PR TITLE
pytest-mock 3.15.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python
     # E   TypeError: assert_argument_introspection.<locals>.<lambda>() got an unexpected keyword argument 'lexer'
     # Upper bound added
-    - pytest <8
+    - pytest >=6.2.5,<8
 
 test:
   source_files:


### PR DESCRIPTION
pytest-mock 3.15.0 

**Destination channel:** Defaults

### Links

- [PKG-9614]
- dev_url:        https://github.com/pytest-dev/pytest-mock/tree/v3.15.0
- conda_forge:    https://github.com/conda-forge/pytest-mock-feedstock
- pypi:           https://pypi.org/project/pytest-mock/3.15.0
- pypi inspector: https://inspector.pypi.io/project/pytest-mock/3.15.0

### Explanation of changes:

- new version number


[PKG-9614]: https://anaconda.atlassian.net/browse/PKG-9614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ